### PR TITLE
Fixed project url in quick start guide

### DIFF
--- a/doc/luadoc/pages/03-quick-start-guide.md
+++ b/doc/luadoc/pages/03-quick-start-guide.md
@@ -52,7 +52,7 @@ jump to the next search result, and `N` to jump to the previous one.
 
 Try the following steps in order:
 
-1. Run `:tabopen luakit.org`, and wait until the page finishes loading.
+1. Run `:tabopen luakit.github.io`, and wait until the page finishes loading.
 2. Press `d`, and the new tab will close.
 3. Press `u`, and the just-closed tab will reappear.
 


### PR DESCRIPTION
I was following the quick start guide, and I noticed that it points to the URL `luakit.org`, which doesn't seem to be related to this project.
I modified the URL to `luakit.github.io`, which is the main page for the project.